### PR TITLE
Recursively watch all top-level git repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
-Dependencies:
-
-Install fswatch.
-```
-brew install fswatch
-```
-
 Source .env file
-
-Listen on a file:
-`fswatch -0 -t --format-time '%F %T %z' README.md | xargs -0 -n 1 -I{} python git_report/display_logs.py '{}'`
 
 Create Dynamo table:
 ```

--- a/bin/observer.py
+++ b/bin/observer.py
@@ -1,0 +1,56 @@
+import argparse
+import time
+import os
+import sys
+from logging import DEBUG, StreamHandler, getLogger
+
+from watchdog.observers.polling import PollingObserver
+
+from git_report.display_logs import (GitEventHandler, RepositoryWatchRegistry,
+                                     SQSMetricsObserver)
+from git_report.repos import find_all_root_repos
+
+log = getLogger(__name__)
+
+BROKER_URL = os.environ.get('GIT_REPORT_BROKER_URL')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "root_path",
+        type=str
+    )
+    parser.add_argument(
+        "--stdout",
+        action='store_true',
+        default=False
+    )
+
+    args = parser.parse_args()
+    if args.stdout:
+        handler = StreamHandler(sys.stdout)
+        handler.setLevel(DEBUG)
+        log.addHandler(handler)
+
+    repo_paths = find_all_root_repos(args.root_path)
+    event_handler = GitEventHandler(observers=[SQSMetricsObserver(BROKER_URL)])
+    observer = PollingObserver()
+
+    for path in repo_paths:
+        log.warning('Observing git repo: {}'.format(path))
+        watch = observer.schedule(event_handler, path, recursive=True)
+        RepositoryWatchRegistry.register(watch)
+
+    try:
+        observer.start()
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        log.warning('Shutdown: Stopping observer due to interrupt. Please wait.')
+
+    try:
+        observer.stop()
+        observer.join()
+    except RuntimeError:
+        # if exiting early enough, and thread hasn't started.
+        pass

--- a/git_report/display_logs.py
+++ b/git_report/display_logs.py
@@ -1,110 +1,77 @@
-import argparse
 import os
-import re
 from datetime import datetime
 from logging import getLogger
-from typing import List, NamedTuple, Tuple, Type, Union
+from typing import List, NamedTuple
 
 import boto3
-from dateutil.parser import parse as parse_datetime
-from watchdog.events import FileSystemMovedEvent, RegexMatchingEventHandler
+from watchdog.events import FileSystemEventHandler, FileSystemMovedEvent
+from watchdog.observers.api import ObservedWatch
 
-from git_report.exceptions import GitReportException
-from git_report.git import find_all_root_repos, get_versioned_files
+from git_report.events import FswatchEvent
+from git_report.repos import is_file_ignored
+from git_report.time import local_time
+from git_report.utils import get_matching_entry
 
 log = getLogger(__name__)
 
-# TODO: Replace the latter group with a valid expression to match all valid files.
-# Otherwise will break for a subset of files.
-BROKER_URL = os.environ.get('GIT_REPORT_BROKER_URL')
-ISO8601_EVENT_REGEX = r'^([\d]{4}-[\d]{2}-[\d]{2} [\d]{2}:[\d]{2}:[\d]{2} [-,+][\d]{4}) ([/.-_a-zA-Z0-9]+)'
 
-
-class GitEventHandler(RegexMatchingEventHandler):
-    def on_moved(event: FileSystemMovedEvent):
-        # TODO: use ._dest_path, .src_path to emit events for both directories,
-        # with dest path coming after src_path.
-        self._add_event(event.src_path)
-        self._add_event(event._dest_path)
-
-    def on_any_event(event):
-        self._add_event(event.src_path)
-
-    def _add_src_event(event):
-        # TODO: check if file is in active source control via get_versioned_files
-        pass
-
-
-class ParserError(GitReportException):
-    pass
-
-
-class FswatchEvent(NamedTuple):
-    timestamp: str
-    file_name: str
+class RepositoryWatchRegistry(object):
+    """
+    Keeps track of observed git repositories, so we don't have to requery
+    the file system tree repetitively.
+    """
+    entries: List[ObservedWatch] = []
 
     @classmethod
-    def coerce(cls, timestamp: str, file_name: str):
-        dt = parse_datetime(timestamp).isoformat()
-        return cls(dt, file_name)
+    def register(cls, watch):
+        cls.entries.append(watch)
 
 
-class FswatchAdapter:
-    """
-    Responsible for taking an unstructured log, output by
-    a listening program, on the display logging file,
-    and formatting into metadata such as date and text,
-    that can be parsed by observers.
-    """
-
-    def __init__(self, parser, observers: List):
-        self.parser = parser
+class GitEventHandler(FileSystemEventHandler):
+    def __init__(self, observers, *args, **kwargs):
+        super(GitEventHandler, self).__init__(*args, **kwargs)
         self.observers = observers
 
-    def publish(self, event: str):
-        formatted_event = self.parse_event(event)
-        for l in self.observers:
-            l.notify(formatted_event, event)
+    def on_moved(self, event: FileSystemMovedEvent):
+        now = local_time()
+        self._add_event(event.src_path, now)
 
-    def parse_event(self, event: str) -> FswatchEvent:
-        return self.parser.parse(event)
+        if self._is_file_in_source_control(event.dest_path):
+            self._add_event(event.dest_path, now)
+
+    def on_any_event(self, event):
+        self._add_event(event.src_path)
+
+    def _is_file_in_source_control(self, path):
+        # first check if it is in a repository,
+        # and then ls the smaller active subtree
+        # to see if it is actually tracked by source control of the repo.
+        # TODO: Just apply the .gitignore regexes to the string directly
+
+        tracked_repo = get_matching_entry(
+            [entry.path for entry in RepositoryWatchRegistry.entries],
+            path
+        )
+        return tracked_repo and not is_file_ignored(path)
+
+    def _add_event(self, path, timestamp=None):
+        if not timestamp:
+            timestamp = local_time()
+
+        event = FswatchEvent(path, timestamp.isoformat())
+        for observer in self.observers:
+            observer.notify(event)
 
 
-class RegexParser:
+class SQSMetricsObserver(object):
     """
-    Responsible for parsing logs, using a regex, into a structured type.
-    """
-
-    def __init__(self, regex: str, event_cls: Type[NamedTuple]):
-        self.regex = re.compile(regex)
-        self.event_cls = event_cls
-
-    def parse(self, event: str) -> NamedTuple:
-        # Probably a better way to do this
-        # Could make this type more specific.
-        match = self.regex.match(event)
-        if not match:
-            raise ParserError(
-                "Could not parse: {}".format(event)
-            )
-        groups = match.groups()
-        if len(groups) != len(self.event_cls._fields):
-            raise ParserError(
-                "Could not parse: {}".format(event)
-            )
-        return self.event_cls.coerce(*groups)
-
-
-class SQSMetricsObserver:
-    """
-    Listens to structured logs, and publishes records to
-    brokers as deemed relevant.
+    Listens to structured logs, and publishes records to SQS broker.
     """
 
     def __init__(self, broker_url):
         self.broker_url = broker_url
 
-    def notify(self, formatted_event: NamedTuple, event: str) -> None:
+    def notify(self, formatted_event: NamedTuple) -> None:
         # Create SQS client
         sqs = boto3.client('sqs')
 
@@ -117,23 +84,10 @@ class SQSMetricsObserver:
                     'StringValue': getattr(formatted_event, field)
                 } for field in formatted_event._fields
             },
-            MessageBody=event
+            MessageBody=str(formatted_event)
         )
+
         if 'MessageId' in response:
-            log.info('Sent Message, ID: {}, Event: {}'.format(response['MessageId'], event))
+            log.info('Sent Message, ID: {}, Event: {}'.format(response['MessageId'], formatted_event))
         else:
-            log.error('Failed to send message: {}'.format(event))
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "log",
-        type=str
-    )
-    args = parser.parse_args()
-    adapter = FswatchAdapter(
-        parser=RegexParser(ISO8601_EVENT_REGEX, FswatchEvent),
-        observers=[SQSMetricsObserver(BROKER_URL)],
-    )
-    adapter.publish(args.log)
+            log.error('Failed to send message: {}'.format(formatted_event))

--- a/git_report/events.py
+++ b/git_report/events.py
@@ -5,10 +5,13 @@ from dateutil import parser
 
 
 class FswatchEvent(NamedTuple):
-    timestamp: str
     file_name: str
+    timestamp: str
 
     @classmethod
     def coerce(cls, timestamp, file_name):
         timestamp = parser.parse(timestamp)
         return cls(str(timestamp), file_name)
+
+    def __str__(self):
+        return "{}, {}".format(self.file_name, self.timestamp)

--- a/git_report/repos.py
+++ b/git_report/repos.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+from typing import List
+
+import git
+from git_report.utils import get_matching_entry
+
+
+def is_git_repo(path) -> bool:
+    try:
+        _ = git.Repo(path)
+        return True
+    except git.exc.InvalidGitRepositoryError:
+        return False
+
+
+def find_all_root_repos(root_path) -> List[str]:
+    abs_root_path = os.path.abspath(root_path)
+    stack = []
+    stack.append(abs_root_path)
+
+    root_directories = set()
+
+    while len(stack):
+        path = stack.pop()
+
+        if is_git_repo(path):
+            root_directories.add(path)
+        else:
+            directories = [
+                _get_abs_path(path, entry)
+                for entry in os.listdir(path)
+                if os.path.isdir(_get_abs_path(path, entry))
+            ]
+            for d in directories:
+                stack.append(d)
+
+    return root_directories
+
+
+def is_file_ignored(file_path):
+    """
+    example git command output:
+
+    M README.md
+    ?? bin/observer.py
+    !! .vscode/
+    !! git_report.egg-info/
+    !! git_report/__pycache__/
+    !! venv/
+    """
+    repo = git.Repo(file_path, search_parent_directories=True)
+    status_files_with_ignored = repo.git.execute(
+        'git status --ignored --porcelain'.split(' ')
+    ).splitlines()
+    ignored_files = [
+        _get_abs_path(repo.working_dir, entry[3:])
+        for entry in status_files_with_ignored
+        if entry.startswith('!!')
+    ]
+
+    return get_matching_entry(ignored_files, file_path) is not None
+
+
+def get_versioned_files(root_path):
+    repo = git.Repo(root_path)
+
+    leaves = repo.git.execute('git ls-files'.split(' ')).splitlines()
+    internal_nodes = repo.git.execute(
+        'git ls-tree HEAD -d -r --name-only {}'.format(root_path).split(' ')
+    ).splitlines()
+
+    return [
+        ",".join([root_path, relative_path])
+        for relative_path in (internal_nodes + leaves)
+    ]
+
+
+def _get_abs_path(root_dir, entry):
+    return "/".join([root_dir, entry])

--- a/git_report/time.py
+++ b/git_report/time.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+from dateutil.tz import tzlocal
+
+
+def local_time():
+    return datetime.now(tzlocal())

--- a/git_report/utils.py
+++ b/git_report/utils.py
@@ -3,6 +3,10 @@ from typing import List
 from gevent import sleep
 from gevent.queue import Queue, Empty
 
+import re
+
+# TODO split this into separate modules
+
 
 def beat_queue(queue, beat_seconds):
     while True:
@@ -22,3 +26,12 @@ def select(*queues: List[Queue]):
 
         yield which, item
         sleep(0)
+
+
+def get_matching_entry(entries: List[str], path):
+    def wildcard_postfix(s): return r"{}*".format(s)
+    return next(iter([
+        e
+        for e in entries
+        if re.search(wildcard_postfix(e), path)
+    ]), None)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='git_report',
     version='0.1',
-    description='Generate git reports.',
+    description='Generate git reports and have them sent back to your command line.',
     url='http://github.com/echrisinger/git_report',
     author='Evan Chrisinger',
     author_email='echrisinger@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         'botocore',
         'boto3>=1.9',
         'gevent>=1.3',
-        'redis',
+        'gitpython',
         'pytz',
+        'watchdog',
     ],
 )


### PR DESCRIPTION
1) Swap out fswatch for watchdog
2) Ignore files that are gitignored
3) Some additional clean up.

Subsequent PR: Rename fswatch events.